### PR TITLE
Moved length and slice filters to swig-extras repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Available Filters
 
 * batch
 * groupby
+* length
 * markdown
 * nl2br
 * pluck
+* slice
 * split
 * trim
 * truncate

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,8 +1,10 @@
 exports.batch = require('./batch');
 exports.groupby = require('./groupby');
+exports.length = require('./length');
 exports.markdown = require('./markdown');
 exports.nl2br = require('./nl2br');
 exports.pluck = require('./pluck');
+exports.slice = require('./slice');
 exports.split = require('./split');
 exports.trim = require('./trim');
 exports.truncate = require('./truncate');

--- a/lib/filters/length.js
+++ b/lib/filters/length.js
@@ -1,0 +1,24 @@
+var utils = require('../utils');
+
+/**
+ * Returns the length of an array or string.
+ *
+ * @example
+ * {{ "foobar"|length }}
+ * // => 6
+ *
+ * @example
+ * {{ [1, 2, 3, 4]|length }}
+ * // => 4
+ *
+ * @example
+ * {{ obj|length }}
+ * // => 3
+ */
+module.exports = function (input) {
+  if (utils.isArray(input) || (typeof input === 'string' || input instanceof String)) {
+    return input.length;
+  }
+
+  return utils.keys(input).length;
+};

--- a/lib/filters/slice.js
+++ b/lib/filters/slice.js
@@ -1,0 +1,14 @@
+/**
+ * Extracts a slice of an array or a string.
+ *
+ * @example
+ * {{ "12345"|slice(1,3) }}
+ * // => 23
+ *
+ * @example
+ * {{ [1, 2, 3, 4, 5]|slice(1, 3) }}
+ * // => [2, 3]
+ */
+module.exports = function (input, start, end) {
+  return input.slice(start, end);
+}

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -24,6 +24,24 @@ describe('Filters:', function () {
     });
   });
 
+  describe('length', function () {
+    extras.useFilter(swig, 'length');
+    it('{{ "foobar"|length }}', function () {
+      expect(swig.render('{{ "foobar"|length }}'))
+        .to.equal('6');
+    });
+
+    it('{{ [1, 2, 3, 4, 5, 6]|length }}', function () {
+      expect(swig.render('{{ [1, 2, 3, 4, 5, 6]|length }}'))
+        .to.equal('6');
+    });
+
+    it('{{ obj|length }}', function () {
+      expect(swig.render('{{ foo|length }}', { locals: { foo: { 'a': 1, 'b': 2, 'c': 3 } }}))
+        .to.equal('3');
+    });
+  });
+
   describe('markdown', function () {
     extras.useFilter(swig, 'markdown');
     it('{{ foo|markdown }}', function () {
@@ -51,6 +69,29 @@ describe('Filters:', function () {
       var opts = { locals: { people: [{ age: 30, name: 'Paul' }, { age: 28, name: 'Nicole'}] }};
       expect(swig.render('{{ people|pluck("name") }}', opts))
         .to.equal('Paul,Nicole');
+    });
+  });
+
+  describe('slice', function () {
+    extras.useFilter(swig, 'slice');
+    it('{{ "12345"|slice(1,3) }}', function () {
+      expect(swig.render('{{ "12345"|slice(1,3) }}'))
+        .to.equal('23');
+    });
+
+    it('{{ "12345"|slice(1) }}', function () {
+      expect(swig.render('{{ "12345"|slice(1) }}'))
+        .to.equal('2345');
+    });
+
+    it('{{ [1, 2, 3, 4, 5]|slice(1,3) }}', function () {
+      expect(swig.render('{{ [1, 2, 3, 4, 5]|slice(1,3) }}'))
+        .to.equal('2,3');
+    });
+
+    it('{{ [1, 2, 3, 4, 5]|slice(1) }}', function () {
+      expect(swig.render('{{ [1, 2, 3, 4, 5]|slice(1) }}'))
+        .to.equal('2,3,4,5');
     });
   });
 


### PR DESCRIPTION
@paularmstrong suggested in PR paularmstrong/swig#335 to move the _length_ and _slice_ filters to this repository instead of swig itself.
